### PR TITLE
Resolve prettier config relative to current file

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -14,11 +14,12 @@ function activate(context) {
   let disposable = vscode.languages.registerDocumentFormattingEditProvider(
     "java",
     {
-      provideDocumentFormattingEdits(document) {
+      async provideDocumentFormattingEdits(document) {
         const text = document.getText();
+        const options = await prettier.resolveConfig(document.fileName);
         const formattedText = prettier.format(text, {
-          parser: "java",
-          tabWidth: 2,
+          ...options,
+          parser: "java"
         });
 
         let textEditor = vscode.window.activeTextEditor;


### PR DESCRIPTION
Use `prettier.resolveConfig` to load .prettierrc relative to the open file being formatted.

This allows settings like

```
{ 
  files: '*.java',
  tabWidth: 4
}
```

defined in project workspace to be respected by the extension.