### PR TITLE
Fix inactive document formatting

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -24,20 +24,14 @@ function activate(context) {
           parser: "java"
         });
 
-        let textEditor = vscode.window.activeTextEditor;
-        if (textEditor) {
-          let firstLine = textEditor.document.lineAt(0);
-          let lastLine = textEditor.document.lineAt(
-            textEditor.document.lineCount - 1
-          );
-          let textRange = new vscode.Range(
-            firstLine.range.start,
-            lastLine.range.end
-          );
+        let firstLine = document.lineAt(0);
+        let lastLine = document.lineAt(document.lineCount - 1);
+        let textRange = new vscode.Range(
+          firstLine.range.start,
+          lastLine.range.end
+        );
 
-          return [vscode.TextEdit.replace(textRange, formattedText)];
-        }
-        return [];
+        return [vscode.TextEdit.replace(textRange, formattedText)];
       },
     }
   );


### PR DESCRIPTION
When "format on save" setting is enabled and "save all open editors" command executed, the formatter miscalculates the number of lines for the inactive editors because `vscode.window.activeTextEditor.document` is used. I changed it to `document` provided in the method signature.